### PR TITLE
Fix marp html export

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "rimraf dist && cpy README.md _config.yml dist && npm run -s deck && npm run -s pdf",
-    "deck": "marp -I ./slides -o ./dist && cpy \"slides/assets/**/*\" dist/assets",
+    "deck": "marp -I ./slides -o ./dist --html && cpy \"slides/assets/**/*\" dist/assets",
     "pdf": "marp --allow-local-files -I ./slides -o ./dist --pdf",
     "now-build": "npm run -s deck",
     "start": "marp -ps ."


### PR DESCRIPTION
Fix Issue #8 by addiing option `--html` to marp-cli